### PR TITLE
chore: fix to many open DB Connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ RESSOURCE_NAME=gpt-35-turbo
 BASE_URL=openai.azure.com
 
 DEFAULT_BACKEND=azure
+
+DATABASE_PATH=postgresql://user:password@server:5432/db?sslmode=disable

--- a/api/apiserver.go
+++ b/api/apiserver.go
@@ -11,13 +11,13 @@ import (
 	"github.com/Masterminds/sprig/v3"
 )
 
-func ApiInit(mux *http.ServeMux, a *auth.Auth) {
+func ApiInit(mux *http.ServeMux, a *auth.Auth, db *db.Database) {
 	timeZone, ok := os.LookupEnv("TIMEZONE")
 	if !ok {
 		timeZone = "Europe/Berlin"
 	}
 
-	api := ApiHandler{db.NewDB(), a, timeZone}
+	api := ApiHandler{db, a, timeZone}
 	mux.HandleFunc("/api2/user/widget", api.GetUserWidget)
 	mux.HandleFunc("/api2/user/logout", api.LogoutUser)
 	mux.HandleFunc("/api2/admin/table/get", api.GetAdminTable)

--- a/apiproxy/validateToken.go
+++ b/apiproxy/validateToken.go
@@ -25,7 +25,7 @@ func CompareToken(hashes []db.ApiKey, apiKey string) (string, error) {
 	return "", err
 }
 
-func ValidateToken(w http.ResponseWriter, r *http.Request) string {
+func (h *baseHandle) ValidateToken(w http.ResponseWriter, r *http.Request) string {
 	header := r.Header.Get(authHeader)
 
 	apiKey := strings.TrimPrefix(header, "Bearer ")
@@ -36,9 +36,7 @@ func ValidateToken(w http.ResponseWriter, r *http.Request) string {
 		return ""
 	}
 
-	db := db.NewDB()
-
-	hashes, err := db.LookupApiKeys("*")
+	hashes, err := h.db.LookupApiKeys("*")
 	if err != nil || len(hashes) == 0 {
 		log.Println("Error while requesting API Keys from DB", err)
 		http.Error(w, "401 - Token Invalid", http.StatusUnauthorized)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,9 @@ import (
 	auth "openai-api-proxy/auth"
 	db "openai-api-proxy/db"
 	web "openai-api-proxy/webui"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/joho/godotenv"
 )
@@ -18,15 +21,35 @@ func main() {
 	if err != nil {
 		log.Println("Warning: not able to loading Env File", err)
 	}
-	db.DatabaseInit()
+	db := db.DatabaseInit()
+	defer db.Close()
+	osExit(db)
+	defer log.Println("Closing DB Clients :)")
+
 	mux := http.NewServeMux()
-	a := auth.Init(mux)
+	a := auth.Init(mux, db)
 	//
-	proxy.Init(mux)        // Start AI Proxy
-	go web.Init(mux, a)    // Start Web UI
-	go api.ApiInit(mux, a) // Start Backend API
+	proxy.Init(mux, db)        // Start AI Proxy
+	go web.Init(mux, a)        // Start Web UI
+	go api.ApiInit(mux, a, db) // Start Backend API
 
 	log.Printf("Serving on http://localhost:%d", 8082)
 	log.Fatal(http.ListenAndServe(":8082", mux))
 
+}
+
+// Close DB on Program Exit
+func osExit(db *db.Database) {
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+	go func() {
+		s := <-sigc
+		log.Printf("Exit: %s Closing DB Clients :)", s)
+		db.Close()
+		os.Exit(1)
+	}()
 }

--- a/db/database.go
+++ b/db/database.go
@@ -24,18 +24,18 @@ type ApiKey struct {
 	TokenCountComplete *int
 }
 
-func DatabaseInit() {
+func DatabaseInit() *Database {
 	createTable, err := os.ReadFile("db/schema.sql")
 	if err != nil {
 		log.Fatal("cannot load schema file: ", err)
 	}
 
 	d := NewDB()
-	defer d.Close()
 	d.Migrate()
 	if _, err := d.db.Exec(string(createTable)); err != nil {
 		log.Fatal(err)
 	}
+	return d
 
 }
 


### PR DESCRIPTION
Closes #21 

- Only Run NewDB a single Time to reduce the number of DB Clients and Connections and remove the Function from Go Routines and Channels
- Add os Exit handler to close open Connections on App Exit